### PR TITLE
fail test when jfx initialization fails, no endless loop

### DIFF
--- a/src/main/java/de/saxsys/javafx/test/SingleJfxApplication.java
+++ b/src/main/java/de/saxsys/javafx/test/SingleJfxApplication.java
@@ -1,9 +1,15 @@
 package de.saxsys.javafx.test;
 
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.ReentrantLock;
+
+import org.junit.runners.model.InitializationError;
 
 import javafx.application.Application;
 import javafx.stage.Stage;
@@ -22,8 +28,10 @@ public class SingleJfxApplication extends Application {
 
 	/**
 	 * Start JavaFx.
+	 * @throws InitializationError 
+	 * @throws InterruptedException 
 	 */
-	public static void startJavaFx() {
+	public static void startJavaFx() throws InitializationError {
 		try {
 			// Lock or wait. This gives another call to this method time to
 			// finish
@@ -33,17 +41,26 @@ public class SingleJfxApplication extends Application {
 			if (!started.get()) {
 				// start the JavaFX application
 				final ExecutorService executor = Executors.newSingleThreadExecutor();
-				executor.execute(() -> SingleJfxApplication.launch());
+				Future<?> jfxLaunchFuture = executor.submit(() -> SingleJfxApplication.launch());
 
 				while (!started.get()) {
+					try {
+						jfxLaunchFuture.get(1, TimeUnit.MILLISECONDS);
+					} catch (InterruptedException | TimeoutException e) {
+						//continue waiting until success or error
+					}
+						
+					
 					Thread.yield();
 				}
 			}
+		} catch (ExecutionException e) {
+			throw new InitializationError(e);
 		} finally {
 			LOCK.unlock();
 		}
 	}
-
+	
 	/**
 	 * Launch.
 	 */


### PR DESCRIPTION
solution of Issue #1

hard to test but it seems to work ;-)
